### PR TITLE
Enable WAL mode for SQLite connections

### DIFF
--- a/absurd-sqlite-extension/src/lib.rs
+++ b/absurd-sqlite-extension/src/lib.rs
@@ -64,6 +64,7 @@ fn absurd_init(db: *mut sqlite3) -> Result<()> {
             "jsonb() requires SQLite 3.45.0+; please upgrade SQLite",
         ));
     }
+    sql::ensure_wal_journal_mode(db)?;
     let flags = FunctionFlags::UTF8 | FunctionFlags::DETERMINISTIC;
     define_scalar_function(db, "absurd_version", 0, absurd_version, flags)?;
     define_scalar_function(db, "absurd_create_queue", 1, absurd_create_queue, flags)?;
@@ -225,6 +226,7 @@ mod tests {
     use super::*;
     use rusqlite::{ffi::sqlite3_auto_extension, params, Connection};
     use std::collections::HashMap;
+    use uuid::Uuid;
 
     #[test]
     fn test_absurd_version() {
@@ -1224,5 +1226,22 @@ mod tests {
             )
             .unwrap();
         assert_eq!(run_state, "cancelled");
+    }
+
+    #[test]
+    fn test_enables_wal_journal_mode_for_file_db() {
+        unsafe {
+            sqlite3_auto_extension(Some(std::mem::transmute(sqlite3_absurd_init as *const ())));
+        }
+
+        let db_path = std::env::temp_dir().join(format!("absurd-wal-{}.db", Uuid::new_v4()));
+        let conn = Connection::open(&db_path).unwrap();
+
+        let journal_mode: String = conn
+            .query_row("pragma journal_mode", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(journal_mode.to_lowercase(), "wal");
+
+        let _ = std::fs::remove_file(db_path);
     }
 }


### PR DESCRIPTION
## Summary
- enable WAL journal mode when the extension initializes connections, tolerating in-memory databases that cannot switch modes
- add a unit test that verifies file-backed databases run in WAL mode by default

## Testing
- cargo fmt -p absurd-sqlite-extension -- --check
- cargo clippy -p absurd-sqlite-extension -- -D warnings
- cargo test -p absurd-sqlite-extension

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586e3a6d188331b77aeb9983ed03e4)