### PR TITLE
[codex] fix sdk ESM imports for Node

### DIFF
--- a/sdks/typescript/LICENSE
+++ b/sdks/typescript/LICENSE
@@ -1,1 +1,201 @@
-../../LICENSE
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@absurd-sqlite/sdk",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@absurd-sqlite/sdk",
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "temporal-polyfill": "^0.3.0"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@absurd-sqlite/sdk",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@absurd-sqlite/sdk",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "temporal-polyfill": "^0.3.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@absurd-sqlite/sdk",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "description": "TypeScript SDK for Absurd-SQLite - SQLite-based durable task execution",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -14,10 +14,11 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc --project tsconfig.build.json && tsc --project tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "build": "node ./scripts/build.mjs",
     "type-check": "tsc --noEmit",
     "prepare": "npm run build",
     "test:prepare": "cd ../../ && cargo build -p absurd-sqlite-extension --release",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@absurd-sqlite/sdk",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "description": "TypeScript SDK for Absurd-SQLite - SQLite-based durable task execution",
+  "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "build": "rm -rf dist && tsc --project tsconfig.build.json && tsc --project tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
     "type-check": "tsc --noEmit",
     "prepare": "npm run build",
     "test:prepare": "cd ../../ && cargo build -p absurd-sqlite-extension --release",

--- a/sdks/typescript/scripts/build.mjs
+++ b/sdks/typescript/scripts/build.mjs
@@ -1,0 +1,36 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(scriptDir, "..");
+const distDir = resolve(rootDir, "dist");
+const tscBinary = resolve(
+  rootDir,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsc.cmd" : "tsc"
+);
+
+rmSync(distDir, { recursive: true, force: true });
+
+run(tscBinary, ["--project", "tsconfig.build.json"]);
+run(tscBinary, ["--project", "tsconfig.cjs.json"]);
+
+mkdirSync(resolve(distDir, "cjs"), { recursive: true });
+writeFileSync(
+  resolve(distDir, "cjs", "package.json"),
+  `${JSON.stringify({ type: "commonjs" })}\n`
+);
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -8,13 +8,13 @@ import {
   type TaskHandler,
   type TaskRegistrationOptions,
   type WorkerOptions,
-} from "./absurd";
-import { SQLiteConnection } from "./sqlite-connection";
+} from "./absurd.js";
+import { SQLiteConnection } from "./sqlite-connection.js";
 
 // Re-export Temporal from temporal-polyfill
 export { Temporal } from "temporal-polyfill";
 
-export type { Queryable } from "./absurd";
+export type { Queryable } from "./absurd.js";
 export {
   CancelledTask,
   SuspendTask,
@@ -31,12 +31,12 @@ export {
   type TaskHandler,
   type TaskRegistrationOptions,
   type WorkerOptions,
-} from "./absurd";
+} from "./absurd.js";
 export {
   downloadExtension,
   resolveExtensionPath,
   type DownloadExtensionOptions,
-} from "./extension-downloader";
+} from "./extension-downloader.js";
 export type {
   SQLiteBindParams,
   SQLiteBindValue,
@@ -45,9 +45,12 @@ export type {
   SQLiteRestBindParams,
   SQLiteStatement,
   SQLiteVerboseLog,
-} from "./sqlite-types";
-export { SQLiteConnection } from "./sqlite-connection";
-export type { SQLiteConnectionOptions, SQLiteValueCodec } from "./sqlite-connection";
+} from "./sqlite-types.js";
+export { SQLiteConnection } from "./sqlite-connection.js";
+export type {
+  SQLiteConnectionOptions,
+  SQLiteValueCodec,
+} from "./sqlite-connection.js";
 
 /**
  * SQLite-specific Absurd client that loads the extension and owns the database handle.

--- a/sdks/typescript/src/sqlite-connection.ts
+++ b/sdks/typescript/src/sqlite-connection.ts
@@ -1,12 +1,12 @@
 import { Temporal } from "temporal-polyfill";
-import type { Queryable } from "./absurd";
+import type { Queryable } from "./absurd.js";
 import type {
   SQLiteColumnDefinition,
   SQLiteDatabase,
   SQLiteStatement,
   SQLiteVerboseLog,
   SQLiteBindValue,
-} from "./sqlite-types";
+} from "./sqlite-types.js";
 
 /**
  * Hooks for encoding parameters and decoding query results.

--- a/sdks/typescript/test/package-entrypoints.test.ts
+++ b/sdks/typescript/test/package-entrypoints.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+const nodeModulesDir = join(packageRoot, "node_modules");
+const npmBinary = process.platform === "win32" ? "npm.cmd" : "npm";
+const tempDirs: string[] = [];
+
+beforeAll(() => {
+  execFileSync(npmBinary, ["run", "build", "--silent"], {
+    cwd: packageRoot,
+    stdio: "inherit",
+  });
+});
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("package entrypoints", () => {
+  it("includes the packaged license text", () => {
+    const packOutput = execFileSync(
+      npmBinary,
+      ["pack", "--json", "--dry-run", "--ignore-scripts", "--silent"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+      }
+    );
+
+    const [{ files }] = JSON.parse(packOutput) as Array<{
+      files: Array<{ path: string }>;
+    }>;
+
+    expect(files.map((file) => file.path)).toContain("LICENSE");
+  });
+
+  it("supports both Node ESM import and CommonJS require", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "absurd-sdk-entrypoints-"));
+    tempDirs.push(tempDir);
+
+    const tempNodeModulesDir = join(tempDir, "node_modules");
+    mkdirSync(join(tempNodeModulesDir, "@absurd-sqlite"), { recursive: true });
+
+    const linkType = process.platform === "win32" ? "junction" : "dir";
+    symlinkSync(
+      packageRoot,
+      join(tempNodeModulesDir, "@absurd-sqlite", "sdk"),
+      linkType
+    );
+    symlinkSync(
+      join(nodeModulesDir, "temporal-polyfill"),
+      join(tempNodeModulesDir, "temporal-polyfill"),
+      linkType
+    );
+
+    const esmOutput = execFileSync(
+      process.execPath,
+      [
+        "-e",
+        [
+          'import("@absurd-sqlite/sdk").then((mod) => {',
+          '  if (typeof mod.Absurd !== "function") {',
+          '    throw new Error("missing Absurd export");',
+          "  }",
+          '  console.log("esm-ok");',
+          "});",
+        ].join("\n"),
+      ],
+      {
+        cwd: tempDir,
+        encoding: "utf8",
+      }
+    );
+
+    const cjsOutput = execFileSync(
+      process.execPath,
+      [
+        "-e",
+        [
+          'const mod = require("@absurd-sqlite/sdk");',
+          'if (typeof mod.Absurd !== "function") {',
+          '  throw new Error("missing Absurd export");',
+          "}",
+          'console.log("cjs-ok");',
+        ].join("\n"),
+      ],
+      {
+        cwd: tempDir,
+        encoding: "utf8",
+      }
+    );
+
+    expect(esmOutput).toContain("esm-ok");
+    expect(cjsOutput).toContain("cjs-ok");
+  });
+});

--- a/sdks/typescript/tsconfig.build.json
+++ b/sdks/typescript/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "moduleResolution": "node"
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "test/**/*.ts"]


### PR DESCRIPTION
## Summary

Fix the TypeScript SDK package so Node can load its published ESM entrypoints without failing on extensionless relative imports.

## What changed

- switched internal ESM source imports to explicit `.js` specifiers
- updated the ESM build to use `NodeNext` resolution
- marked the package as `"type": "module"`
- added an `exports` map for `import` and `require`
- cleaned `dist` before builds and limited published files to the built package contents
- bumped `@absurd-sqlite/sdk` to `0.3.0-alpha.2`

## Root cause

The SDK was publishing ESM files with extensionless relative imports. That works in some bundler-driven environments, but standard Node.js ESM resolution does not resolve those imports by default, which caused `ERR_MODULE_NOT_FOUND` at runtime.

## Impact

Consumers can now install the published SDK tarball and import `@absurd-sqlite/sdk` directly under Node ESM without a postinstall patch.

## Validation

- `npm test` in `sdks/typescript`
- `npm pack`
- installed the packed tarball into a clean temp project
- verified `node -e 'import("@absurd-sqlite/sdk")'`
- verified queue creation and a spawned task with the packed SDK
